### PR TITLE
Satztrennung

### DIFF
--- a/articles-of-association.tex
+++ b/articles-of-association.tex
@@ -311,7 +311,7 @@ Begründung beantragt.
 stattfinden, wenn sichergestellt ist, dass alle stimmberechtigten Mitglieder
 zumutbar teilnehmen können.
 
-'S Die Mitgliederversammlung wird durch den BGB-Vorstand einberufen, er setzt
+'S Die Mitgliederversammlung wird durch den BGB-Vorstand einberufen. Dieser setzt
 rechtzeitig durch Beschluss einen Termin fest.
 'S Die Einladung zur Mitgliederversammlung erfolgt per E-Mail; ihr ist eine vom
 BGB-Vorstand festgelegte Tagesordnung beizufügen.


### PR DESCRIPTION
Aus zwei, durch ein Komma verbundenen, Teilsätzen wurden zwei eigenständige Hauptsätze.
