### PR TITLE
Adapt documents for scrjura 0.9

### DIFF
--- a/articles-of-association.tex
+++ b/articles-of-association.tex
@@ -80,7 +80,7 @@ sind wir wie folgt ÜBEREINGEKOMMEN:
 \newpage
 
 \begin{contract}
-\Paragraph{title={Name, Sitz und Geschäftsjahr}}
+\Clause{title={Name, Sitz und Geschäftsjahr}}
 
 'S Der Verein führt den Namen „Kreativität trifft Technik“.
 
@@ -91,7 +91,7 @@ führen.
 
 'S Das Geschäftsjahr ist das Kalenderjahr.
 
-\Paragraph{title={Zweckbestimmung und Gemeinnützigkeit}}
+\Clause{title={Zweckbestimmung und Gemeinnützigkeit}}
 
 'S Der Verein verfolgt ausschließlich und unmittelbar gemeinnützige Zwecke im
 Sinne des Abschnitts „Steuerbegünstigte Zwecke“ der Abgabenordnung.
@@ -138,7 +138,7 @@ werden.
 'S Keine Person darf durch unverhältnismäßig hohe Vergütungen oder durch
 Ausgaben, die dem Zweck des Vereins fremd sind, begünstigt werden.
 
-\Paragraph{title={Mitgliedschaft}}
+\Clause{title={Mitgliedschaft}}
 
 'S Der Verein besteht aus ordentlichen Mitgliedern, Fördermitgliedern und
 Ehrenmitgliedern.
@@ -158,7 +158,7 @@ wieder entzogen werden.
 'S Auf Ehrenmitglieder finden die Regelungen für ordentliche Mitglieder
 entsprechende Anwendung, soweit diese Satzung nichts Abweichendes bestimmt.
 
-\Paragraph{title={Beginn und Ende der Mitgliedschaft}}
+\Clause{title={Beginn und Ende der Mitgliedschaft}}
 
 'S Die Mitgliedschaft kann gegenüber dem Vorstand in Textform beantragt werden.
 'S Bei beschränkt geschäftsfähigen Minderjährigen ist zur Aufnahme in den
@@ -207,7 +207,7 @@ aus der Mitgliedschaft.
 'S Eine Rückgewähr von Beiträgen, Spenden oder anderen Zuwendungen und
 Unterstützungsleistungen erfolgt nicht.
 
-\Paragraph{title={Rechte und Pflichten der Mitglieder}}
+\Clause{title={Rechte und Pflichten der Mitglieder}}
 
 'S Ordentliche Mitglieder besitzen das aktive und passive Wahlrecht sowie das
 Antrags-, Stimm- und Rederecht in der Mitgliederversammlung.
@@ -249,7 +249,7 @@ des Vereinszwecks dient.
 Vertragsinhalte sowie für eine eventuelle Vertragsbeendigung entscheidet der
 Vorstand.
 
-\Paragraph{title={Aufnahmegebühr und Beiträge}}
+\Clause{title={Aufnahmegebühr und Beiträge}}
 
 'S Für die Erfüllung der satzungsmäßigen Zwecke werden Mittel verwendet, die
 insbesondere durch Beiträge, Spenden und Zuschüsse erlangt werden.
@@ -265,7 +265,7 @@ ganz oder teilweise von der Aufnahmegebühr und der Beitragspflicht befreien.
 'S Die Beitragsordnung kann auch für den Vorstand Kompetenzen zur Befreiung von
 Aufnahmegebühr und Beitragspflicht vorsehen.
 
-\Paragraph{title={Organe des Vereins}}
+\Clause{title={Organe des Vereins}}
 
 'S Organe des Vereins sind
 \begin{enumerate}
@@ -274,7 +274,7 @@ Aufnahmegebühr und Beitragspflicht vorsehen.
 	\item der Beirat.
 \end{enumerate}
 
-\Paragraph{title={Die Mitgliederversammlung}}
+\Clause{title={Die Mitgliederversammlung}}
 
 'S Oberstes Organ des Vereins ist die Mitgliederversammlung.
 'S Sie hat über grundsätzliche Fragen und Angelegenheiten des Vereins zu
@@ -381,7 +381,7 @@ allen ordentlichen Mitgliedern binnen Monatsfrist mitgeteilt.
 'S Die Protokolle werden vom Ersten und vom Zweiten Vorsitzenden sowie vom
 Protokollführer unterzeichnet.
 
-\Paragraph{title={Der Vorstand}}
+\Clause{title={Der Vorstand}}
 
 'S Der Vorstand besteht aus
 \begin{enumerate}
@@ -486,7 +486,7 @@ diesbezüglichen Vertragsbedingungen und Vertragsinhalte, sowie für eine
 eventuelle Vertragsbeendigung entscheidet der Vorstand ohne die Stimme des
 jeweils betroffenen Vorstandsmitglieds.
 
-\Paragraph{title={Der Beirat}}
+\Clause{title={Der Beirat}}
 
 'S Durch Beschluss der Mitgliederversammlung kann ein Beirat eingerichtet
 werden.
@@ -500,7 +500,7 @@ Abstimmungsmehrheit einzeln berufen und abberufen.
 'S Dazu kann er sich eine Geschäftsordnung geben, diese Bedarf nicht der
 Zustimmung der Mitgliederversammlung.
 
-\Paragraph{title={Kassenprüfung}}
+\Clause{title={Kassenprüfung}}
 
 'S Die Mitgliederversammlung wählt zwei Kassenprüfer für die Dauer von einem
 Jahr.
@@ -521,13 +521,13 @@ getätigten Ausgaben.
 'S Die Kassenprüfer unterrichten die Mitgliederversammlung über das Ergebnis
 der Prüfung durch einen gemeinsamen Bericht in Schriftform.
 
-\Paragraph{title={Satzungsänderungen}}
+\Clause{title={Satzungsänderungen}}
 
 'S Die Mitgliederversammlung beschließt Änderungen dieser Satzung mit einer
 Zweidrittelmehrheit der abgegebenen Stimmen.
 'S Absatz 1 findet ebenfalls bei Änderung des Vereinszwecks Anwendung.
 
-\Paragraph{title={Auflösung des Vereins}}
+\Clause{title={Auflösung des Vereins}}
 
 'S Die Auflösung des Vereins kann nur mit einer Zweidrittelmehrheit der
 abgegebenen Stimmen der Mitgliederversammlung beschlossen werden.
@@ -544,7 +544,7 @@ Auflösung des Vereins beschlossen.
 Liquidatoren ernannt, soweit die Mitgliederversammlung keinen abweichenden
 Beschluss fasst.
 
-\Paragraph{title={Form- und Schlussbestimmungen}}
+\Clause{title={Form- und Schlussbestimmungen}}
 
 'S Soweit diese Satzung das Erfordernis der Textform vorsieht, kann dieses
 insbesondere durch Verwendung einer einfachen E-Mail eingehalten werden.

--- a/membership-fee-regulations.tex
+++ b/membership-fee-regulations.tex
@@ -45,7 +45,7 @@
 
 \begin{contract}
 
-\Paragraph{title={Mitgliedsbeiträge}}
+\Clause{title={Mitgliedsbeiträge}}
 
 'S Der monatliche Mitgliedsbeitrag für ordentliche Mitglieder beträgt 25,00
 Euro.
@@ -62,7 +62,7 @@ Euro entrichten.
 ordentliche Mitglieder von der Beitragspflicht ganz oder teilweise befreien
 sowie Stundungsabreden treffen.
 
-\Paragraph{title={Aufnahmegebühren}}
+\Clause{title={Aufnahmegebühren}}
 
 'S Die Aufnahmegebühr für ordentliche Mitglieder und Fördermitglieder beträgt
 10,00 Euro.
@@ -73,7 +73,7 @@ sowie Stundungsabreden treffen.
 ordentliche Mitglieder von der Zahlung der Aufnahmegebühr ganz oder teilweise
 befreien sowie Stundungsabreden treffen.
 
-\Paragraph{title={Ermäßigungen und Befreiungen von der Zahlungspflicht}}
+\Clause{title={Ermäßigungen und Befreiungen von der Zahlungspflicht}}
 
 'S Angehörigen der nachfolgend genannten Personengruppen steht eine Ermäßigung
 des Mitgliedsbeitrags gemäß § 1 Absatz 1 Satz 2 dieser Beitragsordnung zu:
@@ -111,7 +111,7 @@ mit einfacher Abstimmungsmehrheit.
 'S Eine rückwirkende Rücknahme einer Befreiung von der Beitragspflicht ist
 außer in Fällen ungerechtfertigter Bereicherung unzulässig.
 
-\Paragraph{title={Fälligkeit und Zahlungsweise}}
+\Clause{title={Fälligkeit und Zahlungsweise}}
 
 'S Die Mitgliedsbeiträge werden jeweils zum Quartalsanfang (d.h. zum 01.
 Januar, 01. April, 01. Juli und 01. Oktober) im Voraus fällig.
@@ -133,7 +133,7 @@ entrichten.
 werden, sofern dieser zum entsprechenden Zeitpunkt zur Entgegennahme bereit
 ist.
 
-\Paragraph{title={Mahnwesen und Inkasso}}
+\Clause{title={Mahnwesen und Inkasso}}
 
 'S Mitglieder, die mit der Zahlung ihres Beitrages mehr als einen Monat in
 Rückstand sind, sind in Schriftform zu mahnen.
@@ -142,7 +142,7 @@ wiederholen.
 
 'S Über Inkassomaßnahmen jeder Art entscheidet der Schatzmeister.
 
-\Paragraph{title={Pflichtdienste}}
+\Clause{title={Pflichtdienste}}
 
 'S Pflichtdienste sind nicht vorgesehen.
 


### PR DESCRIPTION
The documents as they are won't compile with scrjura 0.9

> It seem that this document was made for scrjura up to version 0.7a.
> Since scrjura version 0.9 \Paragraph, \SubParagraph, and all depending
> commands, options, and counters have been renamed.
> You should replace the terms `Paragraph' and `paragraph` by `Clause` and
> `clause` if they are part of the name of a scrjura feature, otherwise this
> document may produce severall additional error messages and maybe the wrong
> result. Sorry for the inconvenience.